### PR TITLE
Fix Dockerfiles and upgrade to Ubuntu 16.04

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 docker build -t xtreemfs/xtreemfs-common xtreemfs-common
 docker build -t xtreemfs/xtreemfs-dir xtreemfs-dir
 docker build -t xtreemfs/xtreemfs-mrc xtreemfs-mrc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ xtreemfsdir:
   image: xtreemfs/xtreemfs-dir
   net: host
   volumes:
-    - "config-examples/:/xtreemfs_data"
+    - "./config-examples:/xtreemfs_data"
   ports:
     - "30638:30638"
     - "32638:32638"
@@ -13,7 +13,7 @@ xtreemfsmrc:
   image: xtreemfs/xtreemfs-mrc
   net: host
   volumes:
-    - "config-examples/:/xtreemfs_data"
+    - "./config-examples:/xtreemfs_data"
   ports:
     - "30636:30636"
     - "32636:32636"
@@ -22,7 +22,7 @@ xtreemfsosd:
   image: xtreemfs/xtreemfs-osd
   net: host
   volumes:
-    - "config-examples/:/xtreemfs_data"
+    - "./config-examples:/xtreemfs_data"
   ports:
     - "30640:30640"
     - "32640:32640"

--- a/xtreemfs-client/Dockerfile
+++ b/xtreemfs-client/Dockerfile
@@ -1,11 +1,10 @@
 FROM xtreemfs/xtreemfs-common
 MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get -qy install build-essential cmake libfuse-dev \
+RUN apt-get -qy install cmake libfuse-dev \
     libattr1-dev libssl-dev libboost-system-dev libboost-thread-dev \
     libboost-program-options-dev libboost-regex-dev
-RUN cd xtreemfs && make client && make install-client
 
-RUN echo "KERNEL==fuse, MODE=0777" > /etc/udev/rules.d/99-fuse.rules
+RUN cd xtreemfs && \
+    make -j`nproc` client && \
+    make -j`nproc` install-client

--- a/xtreemfs-common/Dockerfile
+++ b/xtreemfs-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -6,8 +6,15 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qy update
 RUN apt-get -qy dist-upgrade
 
-RUN apt-get -qy install git make openjdk-7-jdk ant
+RUN apt-get -qy install \
+    build-essential \
+    git \
+    maven \
+    openjdk-8-jdk
 
-RUN git clone https://github.com/xtreemfs/xtreemfs.git && \
-    cd xtreemfs && \
-	make server
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_INCLUDE_PATH /usr/lib/jvm/java-8-openjdk-amd64/include
+ENV JAVA_INCLUDE_PATH2 /usr/lib/jvm/java-8-openjdk-amd64/include/linux
+
+RUN git clone --depth 1 https://github.com/xtreemfs/xtreemfs.git && \
+    make -j`nproc` -C xtreemfs server

--- a/xtreemfs-dir/Dockerfile
+++ b/xtreemfs-dir/Dockerfile
@@ -1,7 +1,6 @@
 FROM xtreemfs/xtreemfs-common
 MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
-ENV DEBIAN_FRONTEND noninteractive
-
-CMD [ "/usr/bin/java","-ea","-cp","/xtreemfs/java/servers/dist/XtreemFS.jar:/xtreemfs/java/foundation/dist/Foundation.jar:/xtreemfs/java/flease/dist/Flease.jar:/xtreemfs/java/lib/*","org.xtreemfs.dir.DIR","/xtreemfs_data/dirconfig.properties" ]
-
+CMD ["/usr/bin/java", "-ea", \
+     "-cp", "/xtreemfs/java/xtreemfs-servers/target/xtreemfs.jar", \
+     "org.xtreemfs.dir.DIR", "/xtreemfs_data/dirconfig.properties"]

--- a/xtreemfs-mrc/Dockerfile
+++ b/xtreemfs-mrc/Dockerfile
@@ -1,7 +1,6 @@
 FROM xtreemfs/xtreemfs-common
 MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
-ENV DEBIAN_FRONTEND noninteractive
-
-CMD [ "/usr/bin/java","-ea","-cp","/xtreemfs/java/servers/dist/XtreemFS.jar:/xtreemfs/java/foundation/dist/Foundation.jar:/xtreemfs/java/flease/dist/Flease.jar:/xtreemfs/java/lib/*","org.xtreemfs.mrc.MRC","/xtreemfs_data/mrcconfig.properties" ]
-
+CMD ["/usr/bin/java", "-ea", \
+     "-cp", "/xtreemfs/java/xtreemfs-servers/target/xtreemfs.jar", \
+     "org.xtreemfs.mrc.MRC", "/xtreemfs_data/mrcconfig.properties"]

--- a/xtreemfs-osd/Dockerfile
+++ b/xtreemfs-osd/Dockerfile
@@ -1,7 +1,6 @@
 FROM xtreemfs/xtreemfs-common
 MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
-ENV DEBIAN_FRONTEND noninteractive
-
-CMD [ "/usr/bin/java","-ea","-cp","/xtreemfs/java/servers/dist/XtreemFS.jar:/xtreemfs/java/foundation/dist/Foundation.jar:/xtreemfs/java/flease/dist/Flease.jar:/xtreemfs/java/lib/*","org.xtreemfs.osd.OSD","/xtreemfs_data/osdconfig.properties" ]
-
+CMD ["/usr/bin/java", "-ea", \
+     "-cp", "/xtreemfs/java/xtreemfs-servers/target/xtreemfs.jar", \
+     "org.xtreemfs.osd.OSD", "/xtreemfs_data/osdconfig.properties"]


### PR DESCRIPTION
The Dockerfiles as currently in the repo don't work. Ant has been replaced by Maven, the JARs are now a single JAR with a different name, etc. I've fixed this so everything compiles on the first try.

Also now based on Ubuntu 16.04 because newer.

And fixed the docker-compose.yml so that it actually works. (Needed to prefix relative volume paths with `./`, [see the docs](https://docs.docker.com/compose/compose-file/#/volumes-volumedriver).)