### PR TITLE
Update setting of JAVA path environment variables

### DIFF
--- a/xtreemfs-client/Dockerfile
+++ b/xtreemfs-client/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
 RUN apt-get -qy install cmake libfuse-dev \
     libattr1-dev libssl-dev libboost-system-dev libboost-thread-dev \
-    libboost-program-options-dev libboost-regex-dev
+    libboost-program-options-dev libboost-regex-dev \
+    valgrind default-jdk
 
 RUN cd xtreemfs && \
     make -j`nproc` client && \

--- a/xtreemfs-common/Dockerfile
+++ b/xtreemfs-common/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get -qy install \
     maven \
     openjdk-8-jdk
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-ENV JAVA_INCLUDE_PATH /usr/lib/jvm/java-8-openjdk-amd64/include
-ENV JAVA_INCLUDE_PATH2 /usr/lib/jvm/java-8-openjdk-amd64/include/linux
+RUN JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | grep -oP "/.*")
+
+ENV JAVA_HOME ${JAVA_HOME}
+ENV JAVA_INCLUDE_PATH ${JAVA_HOME}/include
+ENV JAVA_INCLUDE_PATH2 ${JAVA_HOME}/include/linux
 
 RUN git clone --depth 1 https://github.com/xtreemfs/xtreemfs.git && \
     make -j`nproc` -C xtreemfs server


### PR DESCRIPTION
On others architecture than amd64, the JAVA_HOME was incorrect and the image build fails:
![2019-07-02 22_31_23-java_not_found](https://user-images.githubusercontent.com/3049704/60551534-db4e3100-9d2b-11e9-8b1f-9bbc05826872.png)

Finding the JAVA_HOME path automatically may improve compatibility.

`docker build -t xtreemfs/xtreemfs-common xtreemfs-common/` now succeed on Raspberry Pi 3B+ (armhf), and still works on Ubuntu LTS 18.04 (amd64).

Fix of missing dependencies `valgrind` and `default-jdk` for building xtreemfs-client.