### PR TITLE
ubuntu 16.04 is EOL -> switch to Debian bookworm-slim for base

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Dockerfiles to run the XtreemFS services in containers.
 
-Before building the XtreemFS images, ensure that you have the current Ubuntu
+Before building the XtreemFS images, ensure that you have the current Debian
 baseimage by running
 
 ```
-docker pull ubuntu
+docker pull debian:bookworm-slim
 ```
 
 The images for the DIR, MRC, and OSD services are derived from a common image

--- a/xtreemfs-client/Dockerfile
+++ b/xtreemfs-client/Dockerfile
@@ -1,5 +1,4 @@
 FROM xtreemfs/xtreemfs-common
-MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
 RUN apt-get -qy install cmake libfuse-dev \
     libattr1-dev libssl-dev libboost-system-dev libboost-thread-dev \

--- a/xtreemfs-common/Dockerfile
+++ b/xtreemfs-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/xtreemfs-common/Dockerfile
+++ b/xtreemfs-common/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:16.04
-MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/xtreemfs-dir/Dockerfile
+++ b/xtreemfs-dir/Dockerfile
@@ -1,5 +1,4 @@
 FROM xtreemfs/xtreemfs-common
-MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
 CMD ["/usr/bin/java", "-ea", \
      "-cp", "/xtreemfs/java/xtreemfs-servers/target/xtreemfs.jar", \

--- a/xtreemfs-mrc/Dockerfile
+++ b/xtreemfs-mrc/Dockerfile
@@ -1,5 +1,4 @@
 FROM xtreemfs/xtreemfs-common
-MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
 CMD ["/usr/bin/java", "-ea", \
      "-cp", "/xtreemfs/java/xtreemfs-servers/target/xtreemfs.jar", \

--- a/xtreemfs-osd/Dockerfile
+++ b/xtreemfs-osd/Dockerfile
@@ -1,5 +1,4 @@
 FROM xtreemfs/xtreemfs-common
-MAINTAINER Christoph Kleineweber <kleineweber@zib.de>
 
 CMD ["/usr/bin/java", "-ea", \
      "-cp", "/xtreemfs/java/xtreemfs-servers/target/xtreemfs.jar", \


### PR DESCRIPTION
This patch set switches out the old Ubuntu 16.04 base image for the modern Debian Bookworm.

Additionally MAINTANER is removed from the Docker files, since that stanza has been deprecated.

README is updated to reflect the changes.

Motivation for switching from Ubuntu to Debian:

Debian is the base distro of Ubuntu and offers the same  features with added stability. Ubuntu has changed many things in recent years, one example being the move to snap packages for many things, while Debian is more predictable. So in a way, switching to Debian is more similar to Ubuntu 16.04 , then Ubuntu 24.04 would be.

Functionally this image should be fully backwards compatible with the old.

I have tested that they build, and anyone interested can try:

```
docker.sunet.se/staas/xtreemfs-client
docker.sunet.se/staas/xtreemfs-common
docker.sunet.se/staas/xtreemfs-dir
docker.sunet.se/staas/xtreemfs-mrc
docker.sunet.se/staas/xtreemfs-osd
```